### PR TITLE
feat: update previewWithdraw to return the deposit ID results

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ represent the amount of their deposited asset.
 The `SimpleTimeLockVault` contract is a ready-to-use vault contract, providing the standard
 time-lock vault functionality such as `deposit`, `withdraw` and `batchWithdraw`.
 
-## Custom Vaults
+## Custom Time-Lock Vaults
 
 Alternatively, you can create your own Solidity vault contract by extending the `TimeLockVault`
 abstract contract and implementing your desired logic.

--- a/contracts/TimeLockVault.sol
+++ b/contracts/TimeLockVault.sol
@@ -165,12 +165,14 @@ abstract contract TimeLockVault is ERC20Upgradeable, ITimeLockVault, TimeLockVau
 
     /**
      * @notice Preview the amount of asset that can be redeemed from the payment IDs
+     * @dev Returns the total amount and an array of boolean indicating whether the specified deposit ID is included in the calculation
      */
     function previewWithdraw(
         address recipient,
         uint256[] calldata depositIds
-    ) external view virtual returns (uint256) {
-        uint256 totalAmount = 0;
+    ) external view virtual returns (uint256 totalAmount, bool[] memory depositIdsIncluded) {
+        totalAmount = 0;
+        depositIdsIncluded = new bool[](depositIds.length);
         for (uint256 i = 0; i < depositIds.length; i++) {
             DepositInfo memory deposit_ = getDeposit(depositIds[i]);
             if (
@@ -178,9 +180,9 @@ abstract contract TimeLockVault is ERC20Upgradeable, ITimeLockVault, TimeLockVau
                 deposit_.redeemTimestamp <= block.timestamp
             ) {
                 totalAmount += deposit_.amount;
+                depositIdsIncluded[i] = true;
             }
         }
-        return totalAmount;
     }
 
     function _deposit(

--- a/contracts/TimeLockVault.sol
+++ b/contracts/TimeLockVault.sol
@@ -165,7 +165,8 @@ abstract contract TimeLockVault is ERC20Upgradeable, ITimeLockVault, TimeLockVau
 
     /**
      * @notice Preview the amount of asset that can be redeemed from the payment IDs
-     * @dev Returns the total amount and an array of boolean indicating whether the specified deposit ID is included in the calculation
+     * @dev Returns the total amount and an array of boolean indicating whether the specified deposit ID is included
+     * in the calculation
      */
     function previewWithdraw(
         address recipient,

--- a/contracts/interfaces/ITimeLockVault.sol
+++ b/contracts/interfaces/ITimeLockVault.sol
@@ -25,7 +25,7 @@ interface ITimeLockVault is IERC20MetadataUpgradeable {
     function previewWithdraw(
         address recipient,
         uint256[] calldata depositIds
-    ) external view returns (uint256);
+    ) external view returns (uint256 totalAmount, bool[] memory depositIdsIncluded);
 
     function totalActiveDepositsOf(address recipient) external view returns (uint256);
 


### PR DESCRIPTION
The return values of `previewWithdraw` will include the total amount that can be withdrawn and an array of booleans indicating the whether the specified deposit ID is included in the preview calculation.