### PR TITLE
fix: retrieve decimals from asset

### DIFF
--- a/contracts/TimeLockVault.sol
+++ b/contracts/TimeLockVault.sol
@@ -99,6 +99,19 @@ abstract contract TimeLockVault is ERC20Upgradeable, ITimeLockVault, TimeLockVau
         return _asset.balanceOf(address(this));
     }
 
+    function decimals()
+        public
+        view
+        virtual
+        override(ERC20Upgradeable, IERC20MetadataUpgradeable)
+        returns (uint8)
+    {
+        if (address(_asset) == address(0)) {
+            revert AssetUndefined();
+        }
+        return _asset.decimals();
+    }
+
     function _setAsset(address asset_) internal {
         _asset = IERC20MetadataUpgradeable(asset_);
     }

--- a/contracts/interfaces/TimeLockVaultErrors.sol
+++ b/contracts/interfaces/TimeLockVaultErrors.sol
@@ -6,6 +6,8 @@ interface TimeLockVaultErrors {
 
     error InvalidActiveDeposit();
 
+    error AssetUndefined();
+
     error DepositNotMatured();
 
     error DepositAlreadyMatured();

--- a/contracts/mocks/MockTimeLockVault.sol
+++ b/contracts/mocks/MockTimeLockVault.sol
@@ -18,4 +18,8 @@ contract MockTimeLockVault is SimpleTimeLockVault {
     ) public returns (DepositInfo memory) {
         return _prematureWithdraw(from, to, depositId);
     }
+
+    function setAssetInternal(address asset_) public {
+        _setAsset(asset_);
+    }
 }

--- a/package.json
+++ b/package.json
@@ -55,8 +55,8 @@
     "typescript": "^4.9.5"
   },
   "dependencies": {
-    "@openzeppelin/contracts": "^4.8.3",
-    "@openzeppelin/contracts-upgradeable": "^4.8.3"
+    "@openzeppelin/contracts": "^4.9.3",
+    "@openzeppelin/contracts-upgradeable": "^4.9.3"
   },
   "files": [
     "/contracts"

--- a/test/TimeLockVault/time-lock-vault-setup.spec.ts
+++ b/test/TimeLockVault/time-lock-vault-setup.spec.ts
@@ -1,5 +1,6 @@
 import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
 import { expect } from "chai";
+import { constants } from "ethers";
 
 import { MockTimeLockVault } from "../../types";
 import { deployMockTimeLockVaultFixture } from "./time-lock-vault.fixture";
@@ -15,10 +16,37 @@ describe("Time-Lock Vault", () => {
   });
 
   describe("Setup", () => {
-    it("should return the correct asset contract address", async () => {
-      const asset = await mockVaultContract.asset();
+    describe("When asset is specified", () => {
+      it("should return the correct asset contract address", async () => {
+        const asset = await mockVaultContract.asset();
 
-      expect(asset).to.equal(fixtures.mockERC20Contract.address);
+        expect(asset).to.equal(fixtures.mockERC20Contract.address);
+      });
+
+      it("should have the same decimals as asset contract", async () => {
+        const decimals = await mockVaultContract.decimals();
+        const assetDecimals = await fixtures.mockERC20Contract.decimals();
+
+        expect(decimals).to.equal(assetDecimals);
+      });
+    });
+
+    describe("When asset is zero address", () => {
+      beforeEach(async () => {
+        await mockVaultContract
+          .connect(fixtures.signers.deployer)
+          .setAssetInternal(constants.AddressZero);
+
+        // Assert that asset is zero address
+        const asset = await mockVaultContract.asset();
+        expect(asset).to.equal(constants.AddressZero);
+      });
+
+      it("should revert when returning decimals", async () => {
+        const tx = mockVaultContract.decimals();
+
+        await expect(tx).to.be.revertedWithCustomError(mockVaultContract, "AssetUndefined");
+      });
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -901,15 +901,15 @@
     table "^6.8.0"
     undici "^5.14.0"
 
-"@openzeppelin/contracts-upgradeable@^4.8.3":
-  version "4.8.3"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.8.3.tgz#6b076a7b751811b90fe3a172a7faeaa603e13a3f"
-  integrity sha512-SXDRl7HKpl2WDoJpn7CK/M9U4Z8gNXDHHChAKh0Iz+Wew3wu6CmFYBeie3je8V0GSXZAIYYwUktSrnW/kwVPtg==
+"@openzeppelin/contracts-upgradeable@^4.9.3":
+  version "4.9.3"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.9.3.tgz#ff17a80fb945f5102571f8efecb5ce5915cc4811"
+  integrity sha512-jjaHAVRMrE4UuZNfDwjlLGDxTHWIOwTJS2ldnc278a0gevfXfPr8hxKEVBGFBE96kl2G3VHDZhUimw/+G3TG2A==
 
-"@openzeppelin/contracts@^4.8.3":
-  version "4.8.3"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.8.3.tgz#cbef3146bfc570849405f59cba18235da95a252a"
-  integrity sha512-bQHV8R9Me8IaJoJ2vPG4rXcL7seB7YVuskr4f+f5RyOStSZetwzkWtoqDMl5erkBJy0lDRUnIR2WIkPiC0GJlg==
+"@openzeppelin/contracts@^4.9.3":
+  version "4.9.3"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.9.3.tgz#00d7a8cf35a475b160b3f0293a6403c511099364"
+  integrity sha512-He3LieZ1pP2TNt5JbkPA4PNT9WC3gOTOlDcFGJW4Le4QKqwmiNJCRt44APfxMxvq7OugU/cqYuPcSBzOw38DAg==
 
 "@scure/base@~1.1.0":
   version "1.1.1"


### PR DESCRIPTION
The `decimals` function was left to the implementer to override and retrieve the decimals from the asset. However, this could have been done within the abstract contract. This PR fixes this issue by implementing a default `decimals` function to get the value from the asset contract if available.